### PR TITLE
Add support for postcss-less syntax

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,9 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and follows [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] - 2022-07-18
+## [1.2.1] - 2022-07-25
 ### Added
-- Support for Less syntax using the PostCSS Less parser..
+- Support for Less syntax using the PostCSS Less parser.
 
 ## [1.2.0] - 2022-04-09
 ### Added
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [1.0.0] - 2021-07-27
 Initial release.
 
-[1.2.0]: https://github.com/Siilwyn/promise-all-props/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/Siilwyn/promise-all-props/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/Siilwyn/promise-all-props/compare/20d0272...v1.0.0
+[1.2.1]: https://github.com/Siilwyn/prettier-plugin-css-order/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/Siilwyn/prettier-plugin-css-order/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/Siilwyn/prettier-plugin-css-order/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/Siilwyn/prettier-plugin-css-order/compare/20d0272...v1.0.0

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and follows [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2022-07-18
+### Added
+- Support for Less syntax using the PostCSS Less parser..
+
 ## [1.2.0] - 2022-04-09
 ### Added
 - New properties from [css-declaration-sorter@6.2.0](https://github.com/Siilwyn/css-declaration-sorter/blob/master/changelog.md#620---2022-03-26).

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and follows [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2022-04-09
+### Added
+- New properties from [css-declaration-sorter@6.2.0](https://github.com/Siilwyn/css-declaration-sorter/blob/master/changelog.md#620---2022-03-26).
+
 ## [1.1.0] - 2022-01-08
 ### Added
 - Support for new SCSS comment syntax using the PostCSS SCSS parser.
@@ -9,5 +13,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [1.0.0] - 2021-07-27
 Initial release.
 
+[1.2.0]: https://github.com/Siilwyn/promise-all-props/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Siilwyn/promise-all-props/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Siilwyn/promise-all-props/compare/20d0272...v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,161 +1,23 @@
 {
   "name": "prettier-plugin-css-order",
-  "version": "1.2.0",
-  "lockfileVersion": 2,
+  "version": "1.2.1",
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "prettier-plugin-css-order",
-      "version": "1.2.0",
-      "license": "ISC",
-      "dependencies": {
-        "css-declaration-sorter": "^6.2.2",
-        "postcss-scss": "^4.0.3",
-        "sync-threads": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "prettier": "2.x"
-      }
-    },
-    "node_modules/colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "peer": true
-    },
-    "node_modules/css-declaration-sorter": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
-      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.9"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
-      "peer": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
-      "peer": true,
-      "dependencies": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
-        "source-map-js": "^0.6.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-scss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
-      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-      "engines": {
-        "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sync-threads": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sync-threads/-/sync-threads-1.0.1.tgz",
-      "integrity": "sha512-hIdwt/c/e1ONnr2RJmfBxEAj/J6KQQWKdToF3Qw8ZNRsTNNteGkOe63rQy9I7J5UNlr8Yl0wkzIr9wgLY94x0Q=="
-    }
-  },
   "dependencies": {
-    "colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "peer": true
-    },
     "css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
-      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-      "requires": {}
+      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg=="
     },
-    "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
-      "peer": true
-    },
-    "postcss": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
-      "peer": true,
-      "requires": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
-        "source-map-js": "^0.6.2"
-      }
+    "postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg=="
     },
     "postcss-scss": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
-      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-      "requires": {}
-    },
-    "prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-      "peer": true
-    },
-    "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-      "peer": true
+      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA=="
     },
     "sync-threads": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "css-declaration-sorter": "^6.2.2",
-        "postcss-scss": "^4.0.2",
+        "postcss-scss": "^4.0.3",
         "sync-threads": "^1.0.1"
       },
       "engines": {
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/postcss-scss": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.2.tgz",
-      "integrity": "sha512-xfdkU128CkKKKVAwkyt0M8OdnelJ3MRcIRAPPQkRpoPeuzWY3RIeg7piRCpZ79MK7Q16diLXMMAD9dN5mauPlQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
+      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
       "engines": {
         "node": ">=12.0"
       },
@@ -140,9 +140,9 @@
       }
     },
     "postcss-scss": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.2.tgz",
-      "integrity": "sha512-xfdkU128CkKKKVAwkyt0M8OdnelJ3MRcIRAPPQkRpoPeuzWY3RIeg7piRCpZ79MK7Q16diLXMMAD9dN5mauPlQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
+      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
       "requires": {}
     },
     "prettier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,188 @@
 {
   "name": "prettier-plugin-css-order",
   "version": "1.2.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "prettier-plugin-css-order",
+      "version": "1.2.1",
+      "license": "ISC",
+      "dependencies": {
+        "css-declaration-sorter": "^6.2.2",
+        "postcss-less": "^6.0.0",
+        "postcss-scss": "^4.0.3",
+        "sync-threads": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prettier": "2.x"
+      }
+    },
+    "node_modules/css-declaration-sorter": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
+      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "peer": true
+    },
+    "node_modules/postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.5"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+      "integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sync-threads": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sync-threads/-/sync-threads-1.0.1.tgz",
+      "integrity": "sha512-hIdwt/c/e1ONnr2RJmfBxEAj/J6KQQWKdToF3Qw8ZNRsTNNteGkOe63rQy9I7J5UNlr8Yl0wkzIr9wgLY94x0Q=="
+    }
+  },
   "dependencies": {
     "css-declaration-sorter": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
-      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
+      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
+      "requires": {}
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "peer": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "peer": true
+    },
+    "postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "peer": true,
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
     },
     "postcss-less": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
-      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg=="
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "requires": {}
     },
     "postcss-scss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
-      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+      "integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
+      "requires": {}
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "peer": true
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "peer": true
     },
     "sync-threads": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prettier-plugin-css-order",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prettier-plugin-css-order",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "css-declaration-sorter": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-css-order",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Sort CSS declarations in a certain order.",
   "type": "commonjs",
   "main": "./src/main.js",
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "css-declaration-sorter": "^6.2.2",
+    "postcss-less": "^6.0.0",
     "postcss-scss": "^4.0.3",
     "sync-threads": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-css-order",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Sort CSS declarations in a certain order.",
   "type": "commonjs",
   "main": "./src/main.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "css-declaration-sorter": "^6.2.2",
-    "postcss-scss": "^4.0.2",
+    "postcss-scss": "^4.0.3",
     "sync-threads": "^1.0.1"
   },
   "peerDependencies": {

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -22,6 +22,18 @@ assert.strictEqual(
   "sorts given SCSS"
 );
 
+assert.strictEqual(
+  prettier.format(
+    "a{\n // something \n font-size: @hi; \n height: 1rem; \n }",
+    {
+      parser: "less",
+      plugins: ["."],
+    }
+  ),
+  "a {\n  height: 1rem;\n  // something\n  font-size: @hi;\n}\n",
+  "sorts given Less"
+);
+
 assert.throws(
   () => prettier.format("/*/*/* x", { parser: "css", plugins: ["."] }),
   "surfaces errors to Prettier"

--- a/src/sorter.js
+++ b/src/sorter.js
@@ -1,13 +1,25 @@
 const postcss = require("postcss");
 const cssDeclarationSorter = require("css-declaration-sorter");
 const { runAsWorker } = require("sync-threads");
+const postcssLess = require("postcss-less");
 const postcssScss = require("postcss-scss");
 
 runAsWorker(async ({ text, parser, pluginOptions }) => {
+  let syntax;
+
+  switch(parser) {
+    case "less":
+      syntax = postcssLess;
+      break;
+    case "scss":
+      syntax = postcssScss;
+      break;
+  }
+
   return postcss([cssDeclarationSorter(pluginOptions)])
     .process(text, {
       from: undefined,
-      syntax: parser === "scss" && postcssScss,
+      syntax,
     })
     .then((result) => result.css);
 });

--- a/src/sorter.js
+++ b/src/sorter.js
@@ -5,21 +5,15 @@ const postcssLess = require("postcss-less");
 const postcssScss = require("postcss-scss");
 
 runAsWorker(async ({ text, parser, pluginOptions }) => {
-  let syntax;
-
-  switch(parser) {
-    case "less":
-      syntax = postcssLess;
-      break;
-    case "scss":
-      syntax = postcssScss;
-      break;
-  }
+  const syntaxMapping = {
+    "less": postcssLess,
+    "scss": postcssScss,
+  };
 
   return postcss([cssDeclarationSorter(pluginOptions)])
     .process(text, {
       from: undefined,
-      syntax,
+      syntax: syntaxMapping[parser],
     })
     .then((result) => result.css);
 });


### PR DESCRIPTION
For now the plugin only supports SCSS postcss syntax.

Example:
create file _test.less_
```
// body {
//   display: none;
// }
```
run `prettier --check test.less`
will return the following:
```
test.less[error] test.less: CssSyntaxError: <css input>:2:6: Unknown word
[error]     at Input.error (/usr/lib/node_modules/postcss/lib/input.js:148:16)
[error]     at Parser.unknownWord (/usr/lib/node_modules/postcss/lib/parser.js:540:22)
[error]     at Parser.decl (/usr/lib/node_modules/postcss/lib/parser.js:219:16)
[error]     at Parser.other (/usr/lib/node_modules/postcss/lib/parser.js:128:18)
[error]     at Parser.parse (/usr/lib/node_modules/postcss/lib/parser.js:72:16)
[error]     at parse (/usr/lib/node_modules/postcss/lib/parse.js:11:12)
[error]     at new LazyResult (/usr/lib/node_modules/postcss/lib/lazy-result.js:133:16)
[error]     at Processor.process (/usr/lib/node_modules/postcss/lib/processor.js:28:14)
[error]     at /usr/lib/node_modules/prettier-plugin-css-order/src/sorter.js:8:6
[error]     at runAsWorker (/usr/lib/node_modules/prettier-plugin-css-order/node_modules/sync-threads/src/index.js:48:18)
```

This pull request adds support for postcss-less the same way it already supports postcss-scss.