### PR TITLE
Fix comment handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ const preprocess = (text, options) => {
     2 * 1024 * 1024
   );
 
-  return sorter({
+  const sortedText = sorter({
     text,
     parser: options.parser,
     pluginOptions: {
@@ -16,6 +16,10 @@ const preprocess = (text, options) => {
       keepOverrides: options.keepOverrides,
     },
   });
+
+  options.originalText = sortedText;
+
+  return sortedText;
 };
 
 module.exports = {

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -38,3 +38,27 @@ assert.throws(
   () => prettier.format("/*/*/* x", { parser: "css", plugins: ["."] }),
   "surfaces errors to Prettier"
 );
+
+assert.strictEqual(
+  prettier.format(
+    "<style>a{\n font-size: 100%; /* font-size comment */ \n height: 1rem; \n }</style>",
+    {
+      parser: "html",
+      plugins: ["."],
+    }
+  ),
+  "<style>\n  a {\n    height: 1rem;\n    font-size: 100%; /* font-size comment */\n  }\n</style>\n",
+  "sorts embedded CSS with comment"
+);
+
+assert.strictEqual(
+  prettier.format(
+    "a{\n font-size: 100%; /* font-size comment */ \n height: 1rem; \n }",
+    {
+      parser: "css",
+      plugins: ["."],
+    }
+  ),
+  "a {\n  height: 1rem;\n  font-size: 100%; /* font-size comment */\n}\n",
+  "sorts CSS with comment"
+);


### PR DESCRIPTION
Overwrite the originalText property with our sorted CSS. The Prettier CSS formatter indexes into the text to pull the comment value, which breaks if the lines have been reordered.

Fixes #23 